### PR TITLE
[Fix] Remove stats config

### DIFF
--- a/webpack/webpack.config.prod.js
+++ b/webpack/webpack.config.prod.js
@@ -42,8 +42,5 @@ module.exports = {
   ],
   optimization: {
     minimizer: [new UglifyJsPlugin(), new OptimizeCSSAssetsPlugin()]
-  },
-  stats: {
-    assets: true
   }
 };


### PR DESCRIPTION
## Summary

- Using `new ManifestPlugin()` for asset info, not stats